### PR TITLE
Partially revert "Revert^4 "Enable full LTO optimization by default""

### DIFF
--- a/cc/lto.go
+++ b/cc/lto.go
@@ -109,8 +109,12 @@ func (lto *lto) flags(ctx ModuleContext, flags Flags) Flags {
 		ltoCFlags := []string{"-flto=thin", "-fsplit-lto-unit"}
 		var ltoLdFlags []string
 
-		// Do not perform costly LTO optimizations for Eng builds.
-		if Bool(lto.Properties.Lto_O0) || ctx.Config().Eng() {
+		// The module did not explicitly turn on LTO. Only leverage LTO's
+		// better dead code elimination and CFG simplification, but do
+		// not perform costly optimizations for a balance between compile
+		// time, binary size and performance.
+		// Apply the same for Eng builds as well.
+		if !lto.ThinLTO() || Bool(lto.Properties.Lto_O0) || ctx.Config().Eng() {
 			ltoLdFlags = append(ltoLdFlags, "-Wl,--lto-O0")
 		}
 


### PR DESCRIPTION
This is a dirty fix to fix the Goodix fingerprint module issue on marble and will probably be reverted until we find a proper fix.

This partially reverts commit df0289bfbdb770d45adcb388c8ebb455eafa81d8.