### PR TITLE
soong: Allow com.thundersoft package on bootclasspath

### DIFF
--- a/scripts/check_boot_jars/package_allowed_list.txt
+++ b/scripts/check_boot_jars/package_allowed_list.txt
@@ -290,6 +290,7 @@ com\.nvidia\..*
 
 # OPLUS adds
 com\.oplus\..*
+com\.thundersoft\..*
 net.oneplus.*
 oplus.*
 vendor.oplus.*


### PR DESCRIPTION
The oplus-fwk library includes a stub for
com.thundersoft.security.ContainerManager, which is referenced by OnePlus Gallery. Add the package prefix to the boot JAR allowed list.

Change-Id: Ica57c3ecbf4c9d2ed69f0e0a333b78a743b97b07